### PR TITLE
fix(planner,schema): made schema and planner independent of schemas composition order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +888,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "tracing-subscriber",
  "warp",
 ]
 
@@ -895,9 +902,11 @@ dependencies = [
  "graphgate-schema",
  "graphgate-validation",
  "indexmap 2.0.2",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -907,6 +916,7 @@ dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
  "indexmap 2.0.2",
+ "pretty_assertions",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -921,6 +931,7 @@ dependencies = [
  "graphgate-schema",
  "indexmap 2.0.2",
  "once_cell",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1728,6 +1739,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3097,6 +3118,12 @@ dependencies = [
  "cfg-if",
  "windows-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ jsonwebtoken = "8.3.0"
 once_cell = "1.18.0"
 opentelemetry = { version = "0.20.0", features = ["metrics"] }
 parser = { version = "6", package = "async-graphql-parser" }
+pretty_assertions = "1.4.0"
 reqwest = { version = "0.11.22", default-features = false, features = ["rustls-tls", "gzip", "brotli", "json"] }
 serde = "1.0.188"
 serde_json = "1.0.107"

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -34,3 +34,6 @@ tokio.workspace = true
 tracing.workspace = true
 value.workspace = true
 warp.workspace = true
+
+[dev-dependencies]
+tracing-subscriber.workspace = true

--- a/crates/handler/src/executor.rs
+++ b/crates/handler/src/executor.rs
@@ -26,6 +26,7 @@ use opentelemetry::{
 };
 use serde::{Deserialize, Deserializer};
 use tokio::sync::{mpsc, Mutex};
+use tracing::instrument;
 use value::{ConstValue, Name, Variables};
 
 use crate::{
@@ -52,6 +53,7 @@ impl<'e> Executor<'e> {
     /// Execute a query plan and return the results.
     ///
     /// Only `Query` and `Mutation` operations are supported.
+    #[instrument(skip(self, fetcher), ret, level = "trace")]
     pub async fn execute_query(self, fetcher: &impl Fetcher, node: &RootNode<'_>) -> Response {
         match node {
             RootNode::Query(node) => {

--- a/crates/handler/tests/expected_response.json
+++ b/crates/handler/tests/expected_response.json
@@ -1,0 +1,39 @@
+{
+  "data": {
+    "collectiblesAll": [
+      {
+        "__typename": "Collectible",
+        "id": "ethereum.0xAd2EB4808b817403005ae020B0662825eE021B0F.51",
+        "name": "A highly effective form of birth control.",
+        "collection": {
+          "__typename": "Collection",
+          "id": "ethereum.0xAd2EB4808b817403005ae020B0662825eE021B0F",
+          "name": "Yat Eggs",
+          "floorPrice": 11
+        }
+      },
+      {
+        "__typename": "Collectible",
+        "id": "ethereum.0x7d256d82b32d8003d1ca1a1526ed211e6e0da9e2.11417",
+        "name": "Fedoras are one of the most fashionable hats around and can look great with a variety of outfits.",
+        "collection": {
+          "__typename": "Collection",
+          "id": "ethereum.0x7d256d82b32d8003d1ca1a1526ed211e6e0da9e2",
+          "name": "Hush Puppies",
+          "floorPrice": 22
+        }
+      },
+      {
+        "__typename": "Collectible",
+        "id": "ethereum.0xa58b5224e2fd94020cb2837231b2b0e4247301a6.970",
+        "name": "This is the last straw. Hat you will wear",
+        "collection": {
+          "__typename": "Collection",
+          "id": "ethereum.0xa58b5224e2fd94020cb2837231b2b0e4247301a6",
+          "name": "Deez Monkeys",
+          "floorPrice": 33
+        }
+      }
+    ]
+  }
+}

--- a/crates/handler/tests/query.txt
+++ b/crates/handler/tests/query.txt
@@ -1,0 +1,13 @@
+query CollectiblesAll {
+  collectiblesAll {
+    __typename
+    id
+    name
+    collection {
+      __typename
+      id
+      name
+      floorPrice
+    }
+  }
+}

--- a/crates/planner/Cargo.toml
+++ b/crates/planner/Cargo.toml
@@ -20,4 +20,6 @@ value.workspace = true
 
 [dev-dependencies]
 globset.workspace = true
+pretty_assertions.workspace = true
 serde_json.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/planner/src/builder.rs
+++ b/crates/planner/src/builder.rs
@@ -20,7 +20,7 @@ use parser::{
     },
     Positioned,
 };
-use tracing::instrument;
+use tracing::{debug, instrument};
 use value::{ConstValue, Name, Value, Variables};
 
 use crate::{

--- a/crates/planner/src/types.rs
+++ b/crates/planner/src/types.rs
@@ -236,6 +236,7 @@ impl<'a> RootGroup<'a> for MutationRootGroup<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct FetchEntity<'a> {
     pub parent_type: &'a MetaType,
     pub prefix: usize,

--- a/crates/planner/tests/collectibles.graphql
+++ b/crates/planner/tests/collectibles.graphql
@@ -1,0 +1,24 @@
+type Collectible @key(fields: "id") {
+        id: ID!
+        name: String!
+        collection: Collection!
+}
+
+type Collection @key(fields: "id", resolvable: false) {
+        id: ID!
+}
+
+
+
+
+type Query {
+        collectiblesAll: [Collectible!]!
+}
+
+
+extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective", "@interfaceObject"]
+)
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/crates/planner/tests/collections.graphql
+++ b/crates/planner/tests/collections.graphql
@@ -1,0 +1,20 @@
+type Collection @key(fields: "id") {
+        id: ID!
+        name: String!
+        floorPrice: Int!
+}
+
+
+
+
+type Query {
+        collectionsAll: [Collection!]!
+}
+
+
+extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective", "@interfaceObject"]
+)
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/crates/planner/tests/federation.text
+++ b/crates/planner/tests/federation.text
@@ -1,0 +1,33 @@
+query CollectiblesAll {
+  collectiblesAll {
+    __typename
+    id
+    name
+    collection {
+      __typename
+      id
+      name
+      floorPrice
+    }
+  }
+}
+---
+{}
+---
+{
+  "type": "sequence",
+  "nodes": [
+    {
+      "type": "fetch",
+      "service": "collectibles",
+      "query": "query\n{ collectiblesAll { __typename id name collection { __typename id __key1___typename:__typename __key1_id:id } } }"
+    },
+    {
+      "type": "flatten",
+      "service": "collections",
+      "path": "[collectiblesAll].collection",
+      "prefix": 1,
+      "query": "query($representations:[_Any!]!) { _entities(representations:$representations) { ... on Collection { name floorPrice } } }"
+    }
+  ]
+}

--- a/crates/planner/tests/test.rs
+++ b/crates/planner/tests/test.rs
@@ -3,6 +3,10 @@ use std::fs;
 use globset::GlobBuilder;
 use graphgate_planner::PlanBuilder;
 use graphgate_schema::ComposedSchema;
+use pretty_assertions::assert_eq;
+use tracing::debug;
+use tracing_subscriber::EnvFilter;
+use value::Name;
 
 #[test]
 fn test() {
@@ -39,13 +43,63 @@ fn test() {
             let expect_node: serde_json::Value = serde_json::from_str(planner_json).unwrap();
             let actual_node = serde_json::to_value(&builder.plan().unwrap()).unwrap();
 
-            // assert_eq!(
-            //     serde_json::to_string_pretty(&actual_node).unwrap(),
-            //     serde_json::to_string_pretty(&expect_node).unwrap(),
-            // );
             assert_eq!(actual_node, expect_node);
 
             n += 1;
         }
+    }
+}
+
+#[test]
+fn test_federation() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .or_else(|_| EnvFilter::try_new("debug"))
+                .unwrap(),
+        )
+        .init();
+    let collections_service_document = parser::parse_schema(include_str!("collections.graphql")).unwrap();
+    let collectibles_service_document = parser::parse_schema(include_str!("collectibles.graphql")).unwrap();
+    let data = fs::read_to_string("./tests/federation.text").unwrap();
+    let mut s = data.split("---");
+    let graphql = s.next().unwrap();
+    let variables = s.next().unwrap();
+    let planner_json = s.next().unwrap();
+    let schema = ComposedSchema::combine([
+        ("collectibles".to_string(), collectibles_service_document.clone()),
+        ("collections".to_string(), collections_service_document.clone()),
+    ])
+    .unwrap();
+    let reverse_order_schema = ComposedSchema::combine([
+        ("collections".to_string(), collections_service_document),
+        ("collectibles".to_string(), collectibles_service_document),
+    ])
+    .unwrap();
+    let document = parser::parse_query(graphql).unwrap();
+    assert_eq!(schema.query_type, reverse_order_schema.query_type);
+    assert_eq!(schema.mutation_type, reverse_order_schema.mutation_type);
+    assert_eq!(schema.subscription_type, reverse_order_schema.subscription_type);
+    assert_eq!(schema.directives, reverse_order_schema.directives);
+    assert_eq!(
+        schema.types.get(&Name::new("Query")),
+        reverse_order_schema.types.get(&Name::new("Query")),
+    );
+    debug!("One order");
+    {
+        // One order
+        let builder = PlanBuilder::new(&schema, document.clone()).variables(serde_json::from_str(variables).unwrap());
+        let expect_node: serde_json::Value = serde_json::from_str(planner_json).unwrap();
+        let actual_node = serde_json::to_value(&builder.plan().unwrap()).unwrap();
+        assert_eq!(actual_node, expect_node);
+    }
+    debug!("Reverse order");
+    {
+        // Reverse order
+        let builder =
+            PlanBuilder::new(&reverse_order_schema, document).variables(serde_json::from_str(variables).unwrap());
+        let expect_node: serde_json::Value = serde_json::from_str(planner_json).unwrap();
+        let actual_node = serde_json::to_value(&builder.plan().unwrap()).unwrap();
+        assert_eq!(actual_node, expect_node);
     }
 }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -17,4 +17,5 @@ tracing.workspace = true
 value.workspace = true
 
 [dev-dependencies]
+pretty_assertions.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/schema/tests/test.rs
+++ b/crates/schema/tests/test.rs
@@ -1,23 +1,36 @@
 use graphgate_schema::ComposedSchema;
-use tracing_subscriber::EnvFilter;
+use parser::types::Type;
+use pretty_assertions::assert_eq;
 
 #[test]
-fn test() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .or_else(|_| EnvFilter::try_new("trace"))
-                .unwrap(),
-        )
-        .init();
+fn test_combine_federated_schemas_should_succeed() {
     let collections_service_document = parser::parse_schema(include_str!("collections.graphql")).unwrap();
     let collectibles_service_document = parser::parse_schema(include_str!("collectibles.graphql")).unwrap();
     let schema = ComposedSchema::combine([
-        ("Collections".to_string(), collections_service_document),
-        ("Collectibles".to_string(), collectibles_service_document),
+        ("collections".to_string(), collections_service_document),
+        ("collectibles".to_string(), collectibles_service_document),
     ])
     .unwrap();
     let query = schema.types.get(&schema.query_type.unwrap()).unwrap();
     dbg!(&query);
     assert!(!query.fields.is_empty());
+}
+
+#[test]
+fn test_combine_federated_schemas_in_any_order_should_return_same_result() {
+    let collections_service_document = parser::parse_schema(include_str!("collections.graphql")).unwrap();
+    let collectibles_service_document = parser::parse_schema(include_str!("collectibles.graphql")).unwrap();
+    let schema_in_asc_order = ComposedSchema::combine([
+        ("collections".to_string(), collections_service_document.clone()),
+        ("collectibles".to_string(), collectibles_service_document.clone()),
+    ])
+    .unwrap();
+    let schema_in_desc_order = ComposedSchema::combine([
+        ("collectibles".to_string(), collectibles_service_document),
+        ("collections".to_string(), collections_service_document),
+    ])
+    .unwrap();
+    let collection_in_asc_order = schema_in_asc_order.get_type(&Type::new("Collection").unwrap());
+    let collection_in_desc_order = schema_in_desc_order.get_type(&Type::new("Collection").unwrap());
+    assert_eq!(collection_in_asc_order, collection_in_desc_order);
 }

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -17,3 +17,4 @@ value.workspace = true
 
 [dev-dependencies]
 once_cell.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/validation/tests/collectibles.graphql
+++ b/crates/validation/tests/collectibles.graphql
@@ -1,0 +1,24 @@
+type Collectible @key(fields: "id") {
+        id: ID!
+        name: String!
+        collection: Collection!
+}
+
+type Collection @key(fields: "id", resolvable: false) {
+        id: ID!
+}
+
+
+
+
+type Query {
+        collectiblesAll: [Collectible!]!
+}
+
+
+extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective", "@interfaceObject"]
+)
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/crates/validation/tests/collectibles_all.txt
+++ b/crates/validation/tests/collectibles_all.txt
@@ -1,0 +1,11 @@
+query CollectiblesAll {
+  collectiblesAll {
+    id
+    name
+    collection {
+      id
+      name
+      floorPrice
+    }
+  }
+}

--- a/crates/validation/tests/collections.graphql
+++ b/crates/validation/tests/collections.graphql
@@ -1,0 +1,20 @@
+type Collection @key(fields: "id") {
+        id: ID!
+        name: String!
+        floorPrice: Int!
+}
+
+
+
+
+type Query {
+        collectionsAll: [Collection!]!
+}
+
+
+extend schema @link(
+        url: "https://specs.apollo.dev/federation/v2.3",
+        import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective", "@interfaceObject"]
+)
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/crates/validation/tests/test.rs
+++ b/crates/validation/tests/test.rs
@@ -1,0 +1,25 @@
+use graphgate_schema::ComposedSchema;
+use tracing_subscriber::EnvFilter;
+use value::Variables;
+
+#[test]
+fn test() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .or_else(|_| EnvFilter::try_new("trace"))
+                .unwrap(),
+        )
+        .init();
+    let collections_service_document = parser::parse_schema(include_str!("collections.graphql")).unwrap();
+    let collectibles_service_document = parser::parse_schema(include_str!("collectibles.graphql")).unwrap();
+    let schema = ComposedSchema::combine([
+        ("Collections".to_string(), collections_service_document),
+        ("Collectibles".to_string(), collectibles_service_document),
+    ])
+    .unwrap();
+    let document = parser::parse_query(include_str!("collectibles_all.txt")).unwrap();
+    let rule_errors = graphgate_validation::check_rules(&schema, &document, &Variables::default());
+    dbg!(&rule_errors);
+    assert!(rule_errors.is_empty());
+}


### PR DESCRIPTION
Part of #3 #5 #2 

The incremental improvement, that this PR brings, relates to `resolvable` field, of Apollo Federation entities, handling.
Previously, if an entity was defined in both schemas, the order of their processing will result in `owner` of that entity type. 
With a check of `resolvable` field in `@key` directive definition, we can skip an assignment of schemas that can't resolve the entity type as `owner` of this type and super-graph schema regardless of sub-graph schemas order in `combine` function arguments.

The PR is an initial step that brings basic capabilities of Apollo Federation entities support in Graph Gate. As I looked through the code, it seems that more changes in design and architecture needed, to correctly handle all scenarios related to it. Current fix will allow only [Referencing an entity without contributing fields](https://www.apollographql.com/docs/federation/entities/#referencing-an-entity-without-contributing-fields) and may not work if additional fields will be contributed to the sub-graph definition or if several (more than 1) sub-graphs will be able to resolve the same entity. 